### PR TITLE
Potential fix for code scanning alert no. 5: Use of insecure SSL/TLS version

### DIFF
--- a/nsaf/core/vulnerability_scanner.py
+++ b/nsaf/core/vulnerability_scanner.py
@@ -187,6 +187,7 @@ class VulnerabilityScanner:
         try:
             # Create SSL context
             context = ssl.create_default_context()
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
             context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
             


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/5](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/5)

To fix the problem, the SSL context created using `ssl.create_default_context()` should explicitly restrict the protocol versions to TLS 1.2 and above. This can be achieved by setting `context.minimum_version = ssl.TLSVersion.TLSv1_2` immediately after the context is created. This will ensure that insecure versions such as SSLv2, SSLv3, TLSv1, and TLSv1.1 cannot be negotiated regardless of system defaults or underlying OpenSSL configuration. The change should be made in the `_analyze_ssl_configuration()` method (lines 183–243), specifically after the context is created on line 189.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
