### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,6 +109,8 @@ jobs:
   build:
     needs: [test, security-scan]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/4](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/4)

To resolve the issue, explicitly set the minimum required permissions for the `build` job. According to the job's steps – building and uploading artifacts – the only required permission is likely `contents: read` (for checking out the code), as the job does not push code, manage issues, or publish packages. The fix is to add a `permissions` block with `contents: read` directly beneath the `runs-on` line in the `build` job definition in `.github/workflows/ci-cd.yml`, as recommended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
