### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,6 +74,8 @@ jobs:
         fail_ci_if_error: false
 
   security-scan:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/3](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/3)

To fix the issue, explicitly add a `permissions` block to the `security-scan` job to restrict the access of the GITHUB_TOKEN. The minimal starting point (per GitHub's recommendation) is `contents: read`, which is sufficient for security scanning tasks that do not need to modify repository contents, issues, or other resources. This change is made within the job definition (between lines 76–100 of `.github/workflows/ci-cd.yml`), typically right after the job name, before `runs-on`. No additional methods or imports are required—just insertion of the permissions YAML property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
