### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/2](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/2)

To resolve the issue, we should explicitly set the job-level permission for the `test` job to restrict the GitHub Actions token to read-only access to repository contents. This is done by adding a `permissions:` field with `contents: read` to the `test` job, immediately below its `runs-on:` key. No other steps in the job require additional permissions, so this is the least-privilege fix. Only the `.github/workflows/ci-cd.yml` file is modified; no need for imports or other code changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
