### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,7 @@
 name: Security Scan
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/1](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block to limit the default GITHUB_TOKEN permissions for this workflow. The best fix is to add the `permissions` block near the top of the file, after the workflow `name` and before the `on` block (workflow level), or at the appropriate job level. This restricts permissions to the least required: `contents: read` for reading repo content, and `issues: write` for creating issues when vulnerabilities are found. No existing functionality will break, since the only writing needed is to issues, and all other job steps (including uploading artifacts) only need read access to contents. The change should be made at the workflow root so it applies to all jobs unless overridden. No extra imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
