### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Create Release
+permissions:
+  contents: write
+  packages: write
 
 # 🚀 RELEASE BRANCH ONLY WORKFLOW
 # This workflow ONLY creates releases from the 'release' branch


### PR DESCRIPTION
Potential fix for [https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/7](https://github.com/tharindushakya/network-security-assessment-framework/security/code-scanning/7)

To fix this issue, we should add a `permissions` block at the workflow level, immediately after the `name:` key and before the `on:` key. This block should specify the least privileges required by the workflow. In this workflow, jobs like `create-release` use actions such as `actions/create-release`, `actions/upload-release-asset`, and push Docker images to GitHub Container Registry. For these steps, the minimal permissions required are typically: `contents: write`, `packages: write`, and optionally `pull-requests: write` (though not used here). If you want to minimize further, analyze which actions need what permissions:
- Creating releases and uploading release assets require `contents: write`
- Docker image push via ghcr.io requires `packages: write`
All other permissions can be left out to restrict access. The fix is to insert the following at line 2:  
```yaml
permissions:
  contents: write
  packages: write
```
If a more restrictive approach is desired (e.g., only `contents: write`), you may test and adjust, but with `ghcr.io` image pushing, `packages: write` is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
