### PR TITLE
 Fix requirements.txt: Remove invalid nmap-python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-nmap-python==1.5.4
 python-nmap==0.7.1
 scapy==2.5.0
 requests>=2.32.4


### PR DESCRIPTION
- Removed non-existent 'nmap-python==1.5.4'
- Kept correct 'python-nmap==0.7.1' package
- All dependencies now install successfully
- NSAF package and CLI working correctly

Fixes installation error:
ERROR: Could not find a version that satisfies the requirement nmap-python==1.5.4